### PR TITLE
mallocated array type cast to `(int *)`

### DIFF
--- a/counting_sort.h
+++ b/counting_sort.h
@@ -13,7 +13,7 @@ Worst case space complexity: O(n+k)
 
 void counting_sort(int arr[], int n, int max_value) {
   int i;
-  int* counts = calloc(max_value, sizeof(*counts));
+  int* counts = (int *) calloc(max_value, sizeof(*counts));
 
   // Create array that holds number of counts
   for (i = 0; i < n; i++) {


### PR DESCRIPTION
type casted mallocated array to `(int *)`